### PR TITLE
fixed flexbox bug causing img to overlap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -97,7 +97,7 @@ img:hover{
 
 .gallery-item{
     max-width:100%;
-    height:100px;
+    height:auto;
 
 }
 
@@ -108,7 +108,7 @@ img:hover{
 
   .gallery-item{
       max-width: 33%;
-      height:100px;
+      height:auto;
   
   }
   
@@ -122,7 +122,7 @@ img:hover{
 
   .gallery-item {
     max-width:25%;
-    height:100px;
+    height:auto;
   }
 
 


### PR DESCRIPTION
fixed flexbox bug causing img to overlap. Also deleted temporary.css due to being useless. 👍 